### PR TITLE
add example for MCCGA as docstring

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -157,3 +157,15 @@
   year={2001},
   publisher={Eidgen{\"o}ssische Technische Hochschule Z{\"u}rich (ETH), Institut f{\"u}r Technische~…}
 }
+
+
+@article{satman2020machine,
+  title   = {Machine Coded Compact Genetic Algorithms for Real Parameter Optimization Problems},
+  author  = {Satman, Mehmet Hakan and Akadal, Emre},
+  journal = {Alphanumeric Journal},
+  volume  = {8},
+  number  = {1},
+  pages   = {43--58},
+  year    = {2020},
+  DOI     = {https://doi.org/10.17093/alphanumeric.576919}
+}

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -159,7 +159,7 @@
 }
 
 
-@article{satman2020machine,
+@article{SatmanAkadal2020mcga,
   title   = {Machine Coded Compact Genetic Algorithms for Real Parameter Optimization Problems},
   author  = {Satman, Mehmet Hakan and Akadal, Emre},
   journal = {Alphanumeric Journal},

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -132,7 +132,7 @@ details.
 
 ## MCCGA
 
-Improved strength Pareto evolutionary algorithm [Zitzler2001](@cite).
+Machine-coded Compact Genetic Algorithms for real-valued optimization problems[satman2020machine](@cite).
 ```@docs
 MCCGA
 ```

--- a/docs/src/algorithms.md
+++ b/docs/src/algorithms.md
@@ -132,7 +132,7 @@ details.
 
 ## MCCGA
 
-Machine-coded Compact Genetic Algorithms for real-valued optimization problems[satman2020machine](@cite).
+Machine-coded Compact Genetic Algorithms for real-valued optimization problems [SatmanAkadal2020mcga](@cite).
 ```@docs
 MCCGA
 ```

--- a/src/algorithms/MCCGA/MCCGA.jl
+++ b/src/algorithms/MCCGA/MCCGA.jl
@@ -20,6 +20,24 @@ end
 - `N` population size
 - `maxsamples` maximum number of samples. 
 
+### Example
+
+```jldoctest
+
+julia> import Optim 
+
+julia> f, bounds, solutions = Metaheuristics.TestProblems.rastrigin();
+
+julia> result = optimize(f, bounds, MCCGA())
+
++=========== RESULT ==========+
+  iteration: 42833
+    minimum: 0
+  minimizer: [-5.677669786379456e-17, 2.7942451898022582e-39, -3.60925916059986e-33, -6.609510861086017e-34, 2.998586759675011e-32, -1.8825832500775007e-38, -3.0729484147585938e-31, 1.7675578057632446e-38, 5.127944874215823e-16, 1.9623770480857484e-19]
+    f calls: 86404
+ total time: 3.2839 s
++============================+
+```
 """
 function MCCGA(;
         N = 100,


### PR DESCRIPTION
This PR adds an example of Rastrigin optimization by using MCCGA. 
