### PR TITLE
add explicit example for MCCGA

### DIFF
--- a/src/algorithms/MCCGA/MCCGA.jl
+++ b/src/algorithms/MCCGA/MCCGA.jl
@@ -58,6 +58,32 @@ julia> result = optimize(f, bounds, MCCGA())
  total time: 3.2839 s
 +============================+
 ```
+
+### Explicit Example 
+
+```jldoctest
+
+julia> using Metaheuristics                                          
+julia> using Optim                                                   
+                                                              
+julia> function f(x::Vector{Float64})::Float64                       
+          return (x[1]-pi)^2 + (x[2]-exp(1))^2                      
+       end                                                           
+                                                              
+julia> bounds = [ -500.0  -500.0;                                    
+                   500.0  500.0]                                      
+                                                              
+result = optimize(f, bounds, MCCGA())
+
++=========== RESULT ==========+
+  iteration: 2974
+    minimum: 1.80997e-09
+  minimizer: [3.1416284249228976, 2.7183048585824263]
+    f calls: 6012
+ total time: 1.5233 s
+stop reason: Other stopping criteria.
++============================+
+```
 """
 function MCCGA(;
         N = 100,

--- a/src/algorithms/MCCGA/MCCGA.jl
+++ b/src/algorithms/MCCGA/MCCGA.jl
@@ -66,14 +66,13 @@ julia> result = optimize(f, bounds, MCCGA())
 julia> using Metaheuristics                                          
 julia> using Optim                                                   
                                                               
-julia> function f(x::Vector{Float64})::Float64                       
-          return (x[1]-pi)^2 + (x[2]-exp(1))^2                      
-       end                                                           
+julia> function f(x::Vector{Float64})::Float64 = (x[1]-pi)^2 + (x[2]-exp(1))^2                                                                                
                                                               
 julia> bounds = [ -500.0  -500.0;                                    
                    500.0  500.0]                                      
-                                                              
-result = optimize(f, bounds, MCCGA())
+
+julia> # Both Metaheuristics and Optim includes optimize() function
+julia> result = Metaheuristics.optimize(f, bounds, MCCGA())
 
 +=========== RESULT ==========+
   iteration: 2974


### PR DESCRIPTION
This PR adds an example for MCCGA.

In this example the function 

$$
y = f(x_1, x_2) = (x_1 - \pi)^2 + (x_2 - exp(1))^2
$$

is minimized where $x_1 = \pi$ and $x_2 = exp(1)$. Function domain is considerable large. 

The result is reported as 

```
+=========== RESULT ==========+
  iteration: 2974
    minimum: 1.80997e-09
  minimizer: [3.1416284249228976, 2.7183048585824263]
    f calls: 6012
 total time: 1.5233 s
stop reason: Other stopping criteria.
+============================+
```

fyi.
