### PR TITLE
Fix #82 #83

### DIFF
--- a/src/core/structures.jl
+++ b/src/core/structures.jl
@@ -31,8 +31,9 @@ function Problem(f::Function, search_space::AbstractSearchSpace; parallel_evalua
     Problem(f, search_space, 0, parallel_evaluation)
 end
 
-function Problem(f::Function, bounds::AbstractMatrix{T}; kargs...) where T <: Number
+function Problem(f::Function, _bounds::AbstractMatrix{T}; kargs...) where T <: Number
     # old problem definition
+    bounds = Array(_bounds)
 
     if size(bounds,1) > 2 && size(bounds,2) == 2
         bounds = Array(bounds')

--- a/src/externals.jl
+++ b/src/externals.jl
@@ -11,7 +11,9 @@ using JMcDM
 using Requires
 using Reexport
 
-@reexport using SearchSpaces
+@reexport import SearchSpaces
+@reexport import SearchSpaces: BoxConstrainedSpace, PermutationSpace, BitArraySpace
+using SearchSpaces
 import SearchSpaces: AbstractSearchSpace,getdim
 import SearchSpaces: AtomicSearchSpace, AbstractSampler, Sampler
 

--- a/src/solutions/individual.jl
+++ b/src/solutions/individual.jl
@@ -245,6 +245,9 @@ end
 
 ##########################################################3
 
+@inline _num_to_vec(v::Number) = [v]
+@inline _num_to_vec(v::Array) = v
+
 function generate_population(N::Int, problem, rng = default_rng_mh();ε=0.0, parallel_evaluation = false)
 
     space = problem.search_space
@@ -254,7 +257,7 @@ function generate_population(N::Int, problem, rng = default_rng_mh();ε=0.0, par
         return create_solutions(X, problem; ε=ε)
     end
     
-    [create_solution(x, problem; ε=ε) for x in rand(rng, space, N)]
+    [create_solution(_num_to_vec(x), problem; ε=ε) for x in rand(rng, space, N)]
 end
 
 

--- a/src/solutions/individual.jl
+++ b/src/solutions/individual.jl
@@ -246,7 +246,7 @@ end
 ##########################################################3
 
 @inline _num_to_vec(v::Number) = [v]
-@inline _num_to_vec(v::Array) = v
+@inline _num_to_vec(v::AbstractArray) = v
 
 function generate_population(N::Int, problem, rng = default_rng_mh();ε=0.0, parallel_evaluation = false)
 

--- a/test/optimize_api.jl
+++ b/test/optimize_api.jl
@@ -15,7 +15,7 @@
         ub = ones(3)
         options = Options(iterations = 10, seed = 1)
         show(IOBuffer(), "text/plain", options)
-        search_spaces = [
+        def_bounds = [
                          (lb, ub),
                          boxconstraints(lb, ub, rigid=false),
                          [lb ub],
@@ -23,20 +23,25 @@
                          [-5; 5;;], # due to #83
                         ]
                         
-        for space in search_spaces
+        for space in def_bounds
             res = optimize(f, space, ECA(;K = 3, options))
             res2 = optimize(f, space, ECA, K = 3, iterations = 10, seed = 1)
             @test minimum(res) == minimum(res2)
         end
-        for space in search_spaces
+        for space in def_bounds
+            p = Metaheuristics.Problem(sum, space)
             for algo in [ABC, DE, PSO, WOA, CGSA, GA, SA]
                 res = optimize(f, space, algo, iterations=3, time_limit=0.1)
-                @test minimizer(res) isa AbstractVector
+                x = minimizer(res)
+                @test x isa AbstractVector
+                @test length(x) == Metaheuristics.getdim(p)
             end
             for algo in [SPEA2, SMS_EMOA, NSGA2, NSGA3]
                 res = optimize(x->([0.0,0],[0.0],[0.0]),
                                space, algo, iterations=3, time_limit=0.1
                               )
+                @test size(positions(res), 2) == Metaheuristics.getdim(p)
+                @test eltype(positions(res)) <: eltype(p.search_space.lb)
             end
         end
 


### PR DESCRIPTION
Changes:

- Avoid reexporting `..` from SearchSpaces (#82)
- add support for AbstractMatrices (convert an `AbstractMatrix{OtherType{T}}` into a `Matrix{T}` as in v3.2) (#83)
- fix the issue on univariate search spaces (#83)

@aplavin 