### PR TITLE
Add rng to docstring for option

### DIFF
--- a/src/core/options.jl
+++ b/src/core/options.jl
@@ -37,6 +37,7 @@ end
         store_convergence::Bool = false,
         debug::Bool = false,
         seed = rand(UInt),
+        rng  = default_rng_mh(seed),
         parallel_evaluation = false,
         verbose = false,
     )


### PR DESCRIPTION
`rng` is described later but not shown in the function's signature