### PR TITLE
Fix integer search spaces with parallel evaluation in NSGA2.

### DIFF
--- a/src/algorithms/multiobjective/NSGA2/NSGA2.jl
+++ b/src/algorithms/multiobjective/NSGA2/NSGA2.jl
@@ -266,7 +266,7 @@ function reproduction(status, parameters::AbstractNSGA, problem, options)
     @assert !isempty(status.population)
 
     N_half = parameters.N
-    Q = zeros(2N_half, getdim(problem))
+    Q = zeros(eltype(get_position(first(status.population))), 2N_half, getdim(problem)) 
 
     for i in 1:N_half
         pa = tournament_selection(status.population, options)

--- a/src/algorithms/multiobjective/NSGA3/NSGA3.jl
+++ b/src/algorithms/multiobjective/NSGA3/NSGA3.jl
@@ -333,8 +333,8 @@ function reproduction(status, parameters::NSGA3, problem)
                                  p_cr = parameters.p_cr,
                                  η_m = parameters.η_m,
                                  p_m = parameters.p_m)
-        Q[i,:] = c1
-        Q[i+1,:] = c2       
+        Q[2i-1,:] = c1
+        Q[2i,:] = c2       
     end
 
     Q

--- a/src/algorithms/multiobjective/NSGA3/NSGA3.jl
+++ b/src/algorithms/multiobjective/NSGA3/NSGA3.jl
@@ -320,7 +320,7 @@ function reproduction(status, parameters::NSGA3, problem)
     @assert !isempty(status.population)
 
     I = randperm(parameters.N)
-    Q = zeros(parameters.N, getdim(problem))
+    Q = zeros(eltype(get_position(first(status.population))), parameters.N, getdim(problem))
     for i = 1:parameters.N ÷ 2
 
         pa = status.population[I[2i-1]]

--- a/src/solutions/individual.jl
+++ b/src/solutions/individual.jl
@@ -216,12 +216,12 @@ function create_child(X::AbstractMatrix,
     #&& error("Error in parallel evaluation: size(X,1) != size(G(X),1).")
     #&& error("Error in parallel evaluation: size(X,1) != size(H(X),1).")
 
-    population = xFgh_indiv[]
+    population = xFgh_solution{Vector{eltype(X)}}[]
 
     for i in 1:size(X,1)
         g = isempty(G) ? zeros(0) : G[i,:]
         h = isempty(H) ? zeros(0) : H[i,:]
-        push!(population, xFgh_indiv(X[i,:], F[i,:], g, h;ε=ε))
+        push!(population, xFgh_solution(X[i,:], F[i,:], g, h, 0, 0.0, violationsSum(g,h;ε=ε), violationsSum(g,h;ε=ε)==0.0))
     end
     population
 end


### PR DESCRIPTION
reproduction() had a 'zeros()' which produced Float64, and a create_child aliased XFgh_indiv (which evaluated to xFgh_solution{Vector{Float64}}).
These are now updated to detect the passed type, so that you can use parallel evaluation=true with integers.

Code seems to work for me; I'm very much scoring function compute bound, so haven't much considered the computational impact, but I suppose eltype() should be quite fast?